### PR TITLE
Validate that global fields work properly in the recording client

### DIFF
--- a/src/clj_honeycomb/fields.clj
+++ b/src/clj_honeycomb/fields.clj
@@ -80,7 +80,10 @@
   (if (or (instance? IBlockingDeref x)
           (instance? IDeref x)
           (instance? IPending x)
-          (instance? Repeat x))
+          (instance? Repeat x)
+          (map? x)
+          (sequential? x)
+          (set? x))
     (->ValueSupplier realize-value x)
     x))
 

--- a/test/clj_honeycomb/fields_test.clj
+++ b/test/clj_honeycomb/fields_test.clj
@@ -56,14 +56,10 @@
     (is (= #{:double
              :exception
              :keyword
-             :list
              :long
-             :map
              :nil
              :ratio
-             :set
-             :string
-             :vector}
+             :string}
            (->> m
                 (remove (comp (partial instance? ValueSupplier) val))
                 (map key)
@@ -76,11 +72,15 @@
              :future-running
              :iterate
              :lazy-seq
+             :list
+             :map
              :promise-delivered
              :promise-pending
              :range
              :ref
              :repeat
+             :set
+             :vector
              :volatile}
            (->> m
                 (filter (comp (partial instance? ValueSupplier) val))


### PR DESCRIPTION
By deferring the evaluation of compound fields (maps, vectors, etc) and evaluating some others (ratios, keywords) early we can ensure that the testing client behaves the same way as the live client.