### PR TITLE
Add an event pre processor hook.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,6 +18,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [clojure-future-spec "1.9.0"]
                  [io.honeycomb.libhoney/libhoney-java ~libhoney-version]]
+  :java-source-paths ["src-java"]
   :pedantic? :abort
   :plugins [[lein-cljfmt "0.6.3"]
             [lein-cloverage "1.0.13" :exclusions [org.clojure/clojure]]

--- a/src-java/clj_honeycomb/Client.java
+++ b/src-java/clj_honeycomb/Client.java
@@ -1,0 +1,50 @@
+package clj_honeycomb;
+
+import clojure.lang.Fn;
+
+import io.honeycomb.libhoney.HoneyClient;
+import io.honeycomb.libhoney.Options;
+import io.honeycomb.libhoney.TransportOptions;
+import io.honeycomb.libhoney.transport.Transport;
+
+/**
+ * An extension of HoneyClient to add support for an event pre-processor
+ * function.
+ */
+public class Client extends HoneyClient {
+    private Fn eventPreProcessor;
+
+    /** {@inheritDoc} */
+    public Client(Options o) {
+        super(o);
+    }
+
+    /** {@inheritDoc} */
+    public Client(Options o, TransportOptions to) {
+        super(o, to);
+    }
+
+    /** {@inheritDoc} */
+    public Client(Options o, Transport t) {
+        super(o, t);
+    }
+
+    /**
+     * Add an event pre-processor function. See the code in clj-honeycomb.core
+     * for the signature and use of this function.
+     *
+     * @param epp The Clojure function to add.
+     */
+    public void setEventPreProcessor(Fn epp) {
+        eventPreProcessor = epp;
+    }
+
+    /**
+     * Get the event pre-processor function, if any.
+     *
+     * @return The Clojure function to use as an event pre-processor.
+     */
+    public Fn getEventPreProcessor() {
+        return eventPreProcessor;
+    }
+}

--- a/src/clj_honeycomb/testing_utils.clj
+++ b/src/clj_honeycomb/testing_utils.clj
@@ -5,7 +5,8 @@
            (io.honeycomb.libhoney HoneyClient
                                   ResponseObserver)
            (io.honeycomb.libhoney.responses ResponseObservable)
-           (io.honeycomb.libhoney.transport Transport)))
+           (io.honeycomb.libhoney.transport Transport)
+           (clj_honeycomb Client)))
 
 (defn- dummy-client
   "Create a HoneyClient that behaves entirely like a regular one but instead
@@ -37,7 +38,7 @@
                         (merge {:data-set "data-set"
                                 :write-key "write-key"}
                                client-options))
-        client (HoneyClient. client-options transport)]
+        client (Client. client-options transport)]
     (when ro
       (.addResponseObserver client ro))
     client))


### PR DESCRIPTION
Allow users of this library to define a function that will process an event and its associated options before handing them off to be sent.