### PR TITLE
Tighten specs and test more

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,6 +25,7 @@
             [lein-codox "0.10.5"]]
   :profiles {:dev {:dependencies [[cloverage "1.0.13" :exclusions [org.clojure/clojure]]
                                   [org.clojure/data.json "0.2.6"]
+                                  [org.clojure/test.check "0.9.0"]
                                   [org.slf4j/slf4j-simple "1.7.25"]
                                   [ring/ring-mock "0.3.2"]
                                   [se.haleby/stub-http "0.2.5"]]

--- a/src/clj_honeycomb/util/keyword.clj
+++ b/src/clj_honeycomb/util/keyword.clj
@@ -1,14 +1,18 @@
 (ns ^:no-doc clj-honeycomb.util.keyword
-  "Utility functions for manipulating keywords")
+  "Utility functions for manipulating keywords"
+  (:require [clojure.spec.alpha :as s]))
+
+(s/fdef stringify-keyword
+  :args (s/cat :k keyword?)
+  :ret string?)
 
 (defn stringify-keyword
   "Convert a keyword to a string without losing the namespace information.
-   Behaves like identity for non-keyword inputs.
 
    k A keyword to turn into a string."
   [k]
-  (if (keyword? k)
-    (if-let [n (namespace k)]
-      (str n "/" (name k))
-      (name k))
-    k))
+  (when-not (keyword? k)
+    (throw (IllegalArgumentException. "Input to stringify-keyword must be a keyword")))
+  (if-let [n (namespace k)]
+    (str n "/" (name k))
+    (name k)))

--- a/test/clj_honeycomb/util/keyword_test.clj
+++ b/test/clj_honeycomb/util/keyword_test.clj
@@ -1,12 +1,24 @@
 (ns clj-honeycomb.util.keyword-test
-  (:require [clojure.test :refer (are deftest)]
+  (:require [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as gen]
+            [clojure.spec.test.alpha :refer (with-instrument-disabled)]
+            [clojure.test :refer (are deftest is testing)]
 
             [clj-honeycomb.util.keyword :as util-keyword]))
 
 (deftest stringify-keyword-works
-  (are [input expected]
-       (= expected (util-keyword/stringify-keyword input))
+  (testing "Valid input"
+    (are [input expected]
+         (= expected (util-keyword/stringify-keyword input))
 
-    nil nil
-    :key "key"
-    :n/key "n/key"))
+      :key "key"
+      :n/key "n/key"))
+  (testing "Invalid input"
+    (with-instrument-disabled
+      (is (thrown? IllegalArgumentException
+                   (util-keyword/stringify-keyword nil)))
+      (is (thrown? IllegalArgumentException
+                   (util-keyword/stringify-keyword 1)))))
+  (testing "Randomly generated input"
+    (doseq [k (gen/sample (s/gen keyword?))]
+      (is (string? (util-keyword/stringify-keyword k))))))

--- a/test/clj_honeycomb/util/map_test.clj
+++ b/test/clj_honeycomb/util/map_test.clj
@@ -1,52 +1,94 @@
 (ns clj-honeycomb.util.map-test
-  (:require [clojure.string :as str]
+  (:require [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as gen]
+            [clojure.spec.test.alpha :refer (with-instrument-disabled)]
+            [clojure.string :as str]
             [clojure.test :refer (are deftest is testing)]
 
             [clj-honeycomb.util.map :as util-map]))
 
 (deftest stringify-keys-works
-  (are [input expected]
-       (= expected (util-map/stringify-keys input))
+  (testing "Valid input"
+    (are [input expected]
+         (= expected (util-map/stringify-keys input))
 
-    nil nil
-    {} {}
-    {:foo :bar} {"foo" :bar}
-    {:foo {:bar :baz}} {"foo" {"bar" :baz}}
-    {{:foo :bar} :baz} {{"foo" :bar} :baz}
-    {:foo/bar :baz/quux} {"foo/bar" :baz/quux}))
+      {} {}
+      {:foo :bar} {"foo" :bar}
+      {:foo {:bar :baz}} {"foo" {"bar" :baz}}
+      {{:foo :bar} :baz} {{"foo" :bar} :baz}
+      {:foo/bar :baz/quux} {"foo/bar" :baz/quux}))
+  (testing "Invalid input"
+    (with-instrument-disabled
+      (is (thrown? IllegalArgumentException (util-map/stringify-keys nil)))
+      (is (thrown? IllegalArgumentException (util-map/stringify-keys [])))))
+  (testing "Randomly generated input"
+    (doseq [m (gen/sample (s/gen map?))]
+      (let [result (util-map/stringify-keys m)]
+        (is (map? result))
+        (is (every? string? (keys result)))))))
 
 (deftest paths-works
-  (are [input expected]
-       (= expected (util-map/paths input))
+  (testing "Valid input"
+    (are [input expected]
+         (= expected (util-map/paths input))
 
-    nil []
-    {} []
-    {:foo :bar} [[:foo]]
-    {:foo :bar :bar {:baz :quux}} [[:foo] [:bar :baz]]))
+      {} []
+      {:foo :bar} [[:foo]]
+      {:foo :bar :bar {:baz :quux}} [[:foo] [:bar :baz]]))
+  (testing "Invalid input"
+    (with-instrument-disabled
+      (is (thrown? IllegalArgumentException (util-map/paths nil)))
+      (is (thrown? IllegalArgumentException (util-map/paths [])))))
+  (testing "Randomly generated input"
+    (doseq [m (gen/sample (s/gen map?))]
+      (let [paths (util-map/paths m)]
+        (is (sequential? paths))
+        (is (every? vector? paths))))))
 
 (deftest flatten-works
   (testing "The basics work"
     (are [input expected]
          (= expected (util-map/flatten identity input))
 
-      nil nil
       {} {}
       {:foo :bar} {[:foo] :bar}
       {:foo :bar :bar {:baz :quux}} {[:foo] :bar [:bar :baz] :quux}))
-  (testing "The key creation function works as expected"
-    (is (= {"foo" :bar
-            "bar.baz" :quux}
-           (util-map/flatten (fn [path]
-                               (str/join "." (map name path)))
-                             {:foo :bar
-                              :bar {:baz :quux}})))))
+  (testing "Invalid input"
+    (with-instrument-disabled
+      (is (thrown? IllegalArgumentException (util-map/flatten nil {})))
+      (is (thrown? IllegalArgumentException (util-map/flatten identity nil)))))
+  (testing "Randomly generated input"
+    (doseq [f (gen/sample (s/gen #{identity}))]
+      (doseq [m (gen/sample (s/gen map?))]
+        (let [res (util-map/flatten f m)]
+          (is (map? res))
+          (doseq [[k v] res]
+            (is (vector? k))
+            (is (not (map? v)))))))))
 
 (deftest flatten-and-stringify-works
-  (are [input expected]
-       (= expected (util-map/flatten-and-stringify "map." input))
+  (testing "Valid input"
+    (are [input expected]
+         (= expected (util-map/flatten-and-stringify "map." input))
 
-    nil nil
-    {} {}
-    {:foo :bar} {"map.foo" :bar}
-    {:foo :bar :bar {:baz :quux}} {"map.foo" :bar "map.bar.baz" :quux}
-    {:foo :bar :bar {1 :quux}} {"map.foo" :bar "map.bar.1" :quux}))
+      {} {}
+      {:foo :bar} {"map.foo" :bar}
+      {:foo :bar :bar {:baz :quux}} {"map.foo" :bar "map.bar.baz" :quux}
+      {:foo :bar :bar {1 :quux}} {"map.foo" :bar "map.bar.1" :quux}))
+  (testing "Invalid input"
+    (with-instrument-disabled
+      (is (thrown? IllegalArgumentException
+                   (util-map/flatten-and-stringify nil {})))
+      (is (thrown? IllegalArgumentException
+                   (util-map/flatten-and-stringify "map." nil)))
+      (is (thrown? IllegalArgumentException
+                   (util-map/flatten-and-stringify "map." [])))))
+  (testing "Randomly generated input"
+    (doseq [prefix (gen/sample (s/gen string?))]
+      (doseq [m (gen/sample (s/gen map?))]
+        (let [res (util-map/flatten-and-stringify prefix m)]
+          (is (map? res))
+          (doseq [[k v] res]
+            (is (string? k))
+            (is (str/starts-with? k prefix))
+            (is (not (map? v)))))))))


### PR DESCRIPTION
Use generators to generate many variants of the spec'ed data structures in order to exercise the specs further. Also tighten the specs to ensure that they better describe the ranges of valid values.