### PR TITLE
Send libhoney's test logs to a file

### DIFF
--- a/dev-resources/logback.xml
+++ b/dev-resources/logback.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="false" scan="true">
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>target/debug.log</file>
+    <encoder>
+      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="INFO">
+    <appender-ref ref="FILE" />
+  </root>
+</configuration>

--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
   :profiles {:dev {:dependencies [[cloverage "1.0.13" :exclusions [org.clojure/clojure]]
                                   [org.clojure/data.json "0.2.6"]
                                   [org.clojure/test.check "0.9.0"]
-                                  [org.slf4j/slf4j-simple "1.7.25"]
+                                  [ch.qos.logback/logback-classic "1.2.3"]
                                   [ring/ring-mock "0.3.2"]
                                   [se.haleby/stub-http "0.2.5"]]
                    :codox {:exclude-vars nil


### PR DESCRIPTION
We only need the libhoney logs when we're debugging something, so we shouldn't clutter up the console with them when running tests from `lein cloverage` or from the REPL.