### PR TITLE
Small test tweaks

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
             [lein-codox "0.10.5"]]
   :profiles {:dev {:dependencies [[cloverage "1.0.13" :exclusions [org.clojure/clojure]]
                                   [org.clojure/data.json "0.2.6"]
-                                  [org.clojure/test.check "0.9.0"]
+                                  [org.clojure/test.check "0.10.0-alpha3"]
                                   [ch.qos.logback/logback-classic "1.2.3"]
                                   [ring/ring-mock "0.3.2"]
                                   [se.haleby/stub-http "0.2.5"]]

--- a/src/clj_honeycomb/core.clj
+++ b/src/clj_honeycomb/core.clj
@@ -27,6 +27,8 @@
                                   TransportOptions)
            (clj_honeycomb Client)))
 
+(set! *warn-on-reflection* true)
+
 (def ^:private pos-java-int?
   "Like pos-int? except within the range of numbers of java.lang.Integer."
   (s/int-in 1 Integer/MAX_VALUE))

--- a/src/clj_honeycomb/fields.clj
+++ b/src/clj_honeycomb/fields.clj
@@ -19,6 +19,8 @@
                          Repeat)
            (io.honeycomb.libhoney ValueSupplier)))
 
+(set! *warn-on-reflection* true)
+
 (s/fdef ->ValueSupplier
   :args (s/cat :f fn?
                :args (s/* any?))

--- a/src/clj_honeycomb/middleware/ring.clj
+++ b/src/clj_honeycomb/middleware/ring.clj
@@ -6,6 +6,8 @@
             [clj-honeycomb.core :as honeycomb]
             [clj-honeycomb.util.map :as map-util]))
 
+(set! *warn-on-reflection* true)
+
 (s/fdef default-extract-request-fields
   :args (s/cat :request map?)
   :ret map?)

--- a/src/clj_honeycomb/testing_utils.clj
+++ b/src/clj_honeycomb/testing_utils.clj
@@ -12,6 +12,8 @@
            (io.honeycomb.libhoney.transport Transport)
            (clj_honeycomb Client)))
 
+(set! *warn-on-reflection* true)
+
 (s/fdef dummy-client
   :args (s/cat :client-options :clj-honeycomb.core/client-options
                :submission-fn fn?)

--- a/src/clj_honeycomb/util/keyword.clj
+++ b/src/clj_honeycomb/util/keyword.clj
@@ -2,6 +2,8 @@
   "Utility functions for manipulating keywords"
   (:require [clojure.spec.alpha :as s]))
 
+(set! *warn-on-reflection* true)
+
 (s/fdef stringify-keyword
   :args (s/cat :k keyword?)
   :ret string?)

--- a/src/clj_honeycomb/util/map.clj
+++ b/src/clj_honeycomb/util/map.clj
@@ -9,6 +9,8 @@
 
             [clj-honeycomb.util.keyword :refer (stringify-keyword)]))
 
+(set! *warn-on-reflection* true)
+
 (s/fdef stringify-keys
   :args (s/cat :m map?)
   :ret map?)

--- a/test/clj_honeycomb/core_test.clj
+++ b/test/clj_honeycomb/core_test.clj
@@ -1,7 +1,5 @@
 (ns clj-honeycomb.core-test
-  (:require [clj-honeycomb.global-fixtures :refer (kitchen-sink-realized make-kitchen-sink)]
-
-            [clojure.data.json :as json]
+  (:require [clojure.data.json :as json]
             [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]
             [clojure.spec.test.alpha :refer (check with-instrument-disabled)]
@@ -10,6 +8,9 @@
             [stub-http.core :as stub-http]
 
             [clj-honeycomb.core :as honeycomb]
+            [clj-honeycomb.fixtures :refer (kitchen-sink-realized
+                                            make-kitchen-sink
+                                            use-fixtures)]
             [clj-honeycomb.testing-utils :refer (no-op-client recording-client validate-events)])
   (:import (clojure.lang ExceptionInfo)
            (stub_http.core NanoFakeServer)
@@ -24,6 +25,10 @@
                                             ServerAccepted
                                             ServerRejected
                                             Unknown)))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures)
 
 (defn- event->fields
   "A helper to extract the fields from an event while avoiding NPEs and ensuring

--- a/test/clj_honeycomb/core_test.clj
+++ b/test/clj_honeycomb/core_test.clj
@@ -549,7 +549,7 @@
                  "bar" "bar"
                  "baz" "baz"}
                 (dissoc event-data "elapsed-ms")))
-         (is (< 100 (get event-data "elapsed-ms" -1) 120))))))
+         (is (< 100 (get event-data "elapsed-ms" -1)))))))
   (testing "Code that throws both throws AND sends the event"
     (validate-events
      (fn []

--- a/test/clj_honeycomb/fields_test.clj
+++ b/test/clj_honeycomb/fields_test.clj
@@ -1,17 +1,22 @@
 (ns clj-honeycomb.fields-test
   (:use [clojure.future])
-  (:require [clj-honeycomb.global-fixtures :refer (kitchen-sink-realized make-kitchen-sink)]
-
-            [clojure.spec.test.alpha :refer (check with-instrument-disabled)]
+  (:require [clojure.spec.test.alpha :refer (check with-instrument-disabled)]
             [clojure.test :refer (are deftest is testing)]
 
-            [clj-honeycomb.fields :as fields])
+            [clj-honeycomb.fields :as fields]
+            [clj-honeycomb.fixtures :refer (kitchen-sink-realized
+                                            make-kitchen-sink
+                                            use-fixtures)])
   (:import (java.util UUID)
            (clojure.lang IBlockingDeref
                          IDeref
                          IPending
                          Repeat)
            (io.honeycomb.libhoney ValueSupplier)))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures)
 
 (deftest ->ValueSupplier-works
   (testing "Simple no-arg function"

--- a/test/clj_honeycomb/fixtures.clj
+++ b/test/clj_honeycomb/fixtures.clj
@@ -1,13 +1,15 @@
-(ns clj-honeycomb.global-fixtures
+(ns clj-honeycomb.fixtures
   "A combination of functions that must get called once and early during
    testing and some global testing data."
   (:require [clojure.spec.test.alpha :as stest]
+            [clojure.test :as clj-test]
             [ring.mock.request :as mock-request])
   (:import (java.util UUID)))
 
-;; Functions which we want called once and early during testing.
-(set! *warn-on-reflection* true)
-(stest/instrument)
+(defn use-fixtures
+  "Install all the fixtures we'll use."
+  []
+  (clj-test/use-fixtures :once #(do (stest/instrument) (%))))
 
 ;; Notes for testing:
 ;;

--- a/test/clj_honeycomb/middleware/ring_test.clj
+++ b/test/clj_honeycomb/middleware/ring_test.clj
@@ -1,18 +1,22 @@
 (ns clj-honeycomb.middleware.ring-test
-  (:require [clj-honeycomb.global-fixtures :refer (sample-ring-request
-                                                   sample-ring-request-extracted
-                                                   sample-ring-response
-                                                   sample-ring-response-extracted)]
-
-            [clojure.spec.alpha :as s]
+  (:require [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]
             [clojure.spec.test.alpha :refer (check)]
             [clojure.test :refer (are deftest is testing)]
 
             [clj-honeycomb.fields :as fields]
+            [clj-honeycomb.fixtures :refer (sample-ring-request
+                                            sample-ring-request-extracted
+                                            sample-ring-response
+                                            sample-ring-response-extracted
+                                            use-fixtures)]
             [clj-honeycomb.middleware.ring :as middle]
             [clj-honeycomb.testing-utils :refer (validate-events)])
   (:import (io.honeycomb.libhoney Event)))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures)
 
 (deftest default-extract-request-fields-works
   (testing "Known values"

--- a/test/clj_honeycomb/testing_utils_test.clj
+++ b/test/clj_honeycomb/testing_utils_test.clj
@@ -1,12 +1,13 @@
 (ns clj-honeycomb.testing-utils-test
-  (:require [clj-honeycomb.global-fixtures :refer (kitchen-sink-realized make-kitchen-sink)]
-
-            [clojure.spec.alpha :as s]
+  (:require [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]
             [clojure.spec.test.alpha :refer (with-instrument-disabled)]
             [clojure.test :refer (deftest is testing)]
 
             [clj-honeycomb.core :as honeycomb]
+            [clj-honeycomb.fixtures :refer (kitchen-sink-realized
+                                            make-kitchen-sink
+                                            use-fixtures)]
             [clj-honeycomb.testing-utils :as tu])
   (:import (io.honeycomb.libhoney Event
                                   HoneyClient
@@ -15,6 +16,10 @@
                                             ServerAccepted
                                             ServerRejected
                                             Unknown)))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures)
 
 (deftest no-op-client-works
   (testing "Default options work"

--- a/test/clj_honeycomb/util/keyword_test.clj
+++ b/test/clj_honeycomb/util/keyword_test.clj
@@ -2,7 +2,12 @@
   (:require [clojure.spec.test.alpha :refer (check with-instrument-disabled)]
             [clojure.test :refer (are deftest is testing)]
 
+            [clj-honeycomb.fixtures :refer (use-fixtures)]
             [clj-honeycomb.util.keyword :as util-keyword]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures)
 
 (deftest stringify-keyword-works
   (testing "Valid input"

--- a/test/clj_honeycomb/util/map_test.clj
+++ b/test/clj_honeycomb/util/map_test.clj
@@ -2,7 +2,12 @@
   (:require [clojure.spec.test.alpha :refer (check with-instrument-disabled)]
             [clojure.test :refer (are deftest is testing)]
 
+            [clj-honeycomb.fixtures :refer (use-fixtures)]
             [clj-honeycomb.util.map :as util-map]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures)
 
 (deftest stringify-keys-works
   (testing "Valid input"


### PR DESCRIPTION
- Fix `lein test`.
- Stop a timing test from being flaky.
- Make `*warn-on-reflection*` work.