### PR TITLE
More linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,14 @@ jobs:
       - restore_cache:
           keys:
             - v1-m2-{{ checksum "project.clj" }}
+      - run:
+          name: joker --lint
+          command: |
+            curl -Lso joker.zip https://github.com/candid82/joker/releases/download/v0.11.1/joker-0.11.1-linux-amd64.zip
+            unzip joker.zip
+            echo '{:known-macros [clojure.spec.alpha/fdef] :rules {:if-without-else true :unused-fn-parameters true}}' > ~/.joker
+            find src test -type f -name '*.clj' -print0 | \
+              xargs -0 -n1 ./joker --lint
       - run: lein cljfmt check
       - run: lein kibit
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
           keys:
             - v1-m2-{{ checksum "project.clj" }}
       - run: lein cljfmt check
+      - run: lein kibit
   test:
     docker:
       - image: circleci/clojure

--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,8 @@
   :pedantic? :abort
   :plugins [[lein-cljfmt "0.6.3"]
             [lein-cloverage "1.0.13" :exclusions [org.clojure/clojure]]
-            [lein-codox "0.10.5"]]
+            [lein-codox "0.10.5"]
+            [lein-kibit "0.1.6"]]
   :profiles {:dev {:dependencies [[cloverage "1.0.13" :exclusions [org.clojure/clojure]]
                                   [org.clojure/data.json "0.2.6"]
                                   [org.clojure/test.check "0.10.0-alpha3"]


### PR DESCRIPTION
Lint with `lein kibit` and `joker --lint` during CI to keep this codebase squeaky clean.