### PR TITLE
Upgrade libhoney to 1.0.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,5 +169,5 @@ jobs:
       - run:
           name: Tag the release
           command: |
-            git tag "1.0.2.${CIRCLE_BUILD_NUM}"
+            git tag "1.0.6.${CIRCLE_BUILD_NUM}"
             git push --tags

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # clj-honeycomb
 
 A library for sending events to [Honeycomb.io](https://www.honeycomb.io/),
-wrapping [libhoney-java 1.0.2](https://github.com/honeycombio/libhoney-java).
+wrapping [libhoney-java 1.0.6](https://github.com/honeycombio/libhoney-java).
 
 [![Clojars Project](https://img.shields.io/clojars/v/conormcd/clj-honeycomb.svg)](https://clojars.org/conormcd/clj-honeycomb)
 [![CircleCI](https://circleci.com/gh/conormcd/clj-honeycomb.svg?style=svg)](https://circleci.com/gh/conormcd/clj-honeycomb)
@@ -23,9 +23,9 @@ wrapping [libhoney-java 1.0.2](https://github.com/honeycombio/libhoney-java).
 Include the following in your `project.clj`:
 
 ```clojure
-; This is libhoney-java 1.0.2 build number 1 on CircleCI
+; This is libhoney-java 1.0.6 build number 1 on CircleCI
 ; The most recent version can be found via the Clojars badge above
-[conormcd/clj-honeycomb "1.0.2.1"]
+[conormcd/clj-honeycomb "1.0.6.1"]
 ```
 
 Then initialize the library somewhere:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def libhoney-version "1.0.2")
+(def libhoney-version "1.0.6")
 
 (defproject conormcd/clj-honeycomb (str libhoney-version
                                         (or (some->> "CIRCLE_BUILD_NUM" System/getenv (str "."))

--- a/src/clj_honeycomb/core.clj
+++ b/src/clj_honeycomb/core.clj
@@ -37,6 +37,7 @@
     #(s/gen #{nil
               (fn [_] nil)})))
 
+(s/def ::additional-user-agent (s/and string? seq))
 (s/def ::api-host (s/and string? seq))
 (s/def ::batch-size pos-java-int?)
 (s/def ::batch-timeout-millis pos-java-int?)
@@ -74,7 +75,8 @@
                    ::on-server-rejected
                    ::on-unknown]))
 (s/def ::transport-options
-  (s/keys :opt-un [::batch-size
+  (s/keys :opt-un [::additional-user-agent
+                   ::batch-size
                    ::batch-timeout-millis
                    ::buffer-size
                    ::connection-request-timeout
@@ -140,7 +142,8 @@
 
 (defn- transport-options
   "Turn a map into a TransportOptions object to initialize the LibHoney client."
-  [{:keys [batch-size
+  [{:keys [additional-user-agent
+           batch-size
            batch-timeout-millis
            buffer-size
            connection-request-timeout
@@ -153,6 +156,7 @@
            queue-capacity
            socket-timeout]}]
   (.build (cond-> (LibHoney/transportOptions)
+            additional-user-agent (.setAdditionalUserAgent additional-user-agent)
             batch-size (.setBatchSize batch-size)
             batch-timeout-millis (.setBatchTimeoutMillis batch-timeout-millis)
             buffer-size (.setBufferSize buffer-size)
@@ -245,6 +249,7 @@
                          documentation for TransportOptions to understand their
                          exact meanings.
 
+                         :additional-user-agent
                          :batch-size
                          :batch-timeout-millis
                          :buffer-size

--- a/test/clj_honeycomb/core_test.clj
+++ b/test/clj_honeycomb/core_test.clj
@@ -135,7 +135,8 @@
 (deftest transport-options-works
   ; By hardcoding these transport options here, this test will also detect
   ; changes in the underlying libhoney-java library.
-  (let [default-transport-options {:batchSize 50
+  (let [default-transport-options {:additionalUserAgent ""
+                                   :batchSize 50
                                    :batchTimeoutMillis 100
                                    :bufferSize 8192
                                    :connectTimeout 0
@@ -159,6 +160,9 @@
 
       {}
       default-transport-options
+
+      {:additional-user-agent "foo"}
+      (assoc default-transport-options :additionalUserAgent "foo")
 
       {:batch-size 100}
       (assoc default-transport-options :batchSize 100)


### PR DESCRIPTION
Libhoney changes:

- honeycombio/libhoney-java#5 - Add the ability to specify an additional user agent string.
- honeycombio/libhoney-java#6 - Bumped the included version of the Jackson libraries from 2.9.5 to 2.9.8 to address some security vulnerabilities.
- honeycombio/libhoney-java#7 - Fix a timestamp formatting bug where there was an unneeded leading '0' on the milliseconds portion.
- honeycombio/libhoney-java#8 - Only log 401 errors if there are no observers attached.

clj-honeycomb changes:

- Accommodate additional user agents with another field in the transport options map.